### PR TITLE
feat(bridge): Rozo SDK upgrade + react-doctor state-flow fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "dependencies": {
     "@creit.tech/stellar-wallets-kit": "^1.9.5",
     "@defindex/sdk": "0.3.0-alpha.1",
-    "@rozoai/intent-common": "0.1.21",
-    "@rozoai/intent-pay": "0.1.34",
+    "@rozoai/intent-common": "0.1.26",
+    "@rozoai/intent-pay": "0.1.39",
     "@soroswap/sdk": "0.4.0",
     "@stellar/stellar-sdk": "14.1.1",
     "@tanstack/react-query": "^5.90.12",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "dependencies": {
     "@creit.tech/stellar-wallets-kit": "^1.9.5",
     "@defindex/sdk": "0.3.0-alpha.1",
-    "@rozoai/intent-common": "0.1.5",
-    "@rozoai/intent-pay": "0.1.4",
+    "@rozoai/intent-common": "0.1.21",
+    "@rozoai/intent-pay": "0.1.34",
     "@soroswap/sdk": "0.4.0",
     "@stellar/stellar-sdk": "14.1.1",
     "@tanstack/react-query": "^5.90.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,16 +10,16 @@ importers:
     dependencies:
       '@creit.tech/stellar-wallets-kit':
         specifier: ^1.9.5
-        version: 1.9.5(cc274b20850c1f3d16c0d46698b20656)
+        version: 1.9.5(0bf60eba65f72a2bc752b927274fc22b)
       '@defindex/sdk':
         specifier: 0.3.0-alpha.1
         version: 0.3.0-alpha.1
       '@rozoai/intent-common':
-        specifier: 0.1.5
-        version: 0.1.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+        specifier: 0.1.21
+        version: 0.1.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@rozoai/intent-pay':
-        specifier: 0.1.4
-        version: 0.1.4(6bc0fb300f5ab6b37fe23369862ef2d5)
+        specifier: 0.1.34
+        version: 0.1.34(d990a992352e99d7b2389237b3e34b2b)
       '@soroswap/sdk':
         specifier: 0.4.0
         version: 0.4.0
@@ -110,9 +110,6 @@ packages:
 
   '@albedo-link/intent@0.12.0':
     resolution: {integrity: sha512-UlGBhi0qASDYOjLrOL4484vQ26Ee3zTK2oAgvPMClOs+1XNk3zbs3dECKZv+wqeSI8SkHow8mXLTa16eVh+dQA==}
-
-  '@albedo-link/intent@0.13.0':
-    resolution: {integrity: sha512-A8CBXqGQEBMXhwxNXj5inC6HLjyx5Do7jW99NOFeecYd1nPUq8gfM0tvoNoR8H8JQ11aTl9tyQBuu/+l3xeBnQ==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -718,9 +715,11 @@ packages:
 
   '@metamask/sdk-analytics@0.0.5':
     resolution: {integrity: sha512-fDah+keS1RjSUlC8GmYXvx6Y26s3Ax1U9hGpWb6GSY5SAdmTSIqp2CvYy6yW0WgLhnYhW+6xERuD0eVqV63QIQ==}
+    deprecated: No longer maintained, superseded by @metamask/connect-analytics
 
   '@metamask/sdk-communication-layer@0.33.1':
     resolution: {integrity: sha512-0bI9hkysxcfbZ/lk0T2+aKVo1j0ynQVTuB3sJ5ssPWlz+Z3VwveCkP1O7EVu1tsVVCb0YV5WxK9zmURu2FIiaA==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
     peerDependencies:
       cross-fetch: ^4.0.0
       eciesjs: '*'
@@ -730,9 +729,11 @@ packages:
 
   '@metamask/sdk-install-modal-web@0.32.1':
     resolution: {integrity: sha512-MGmAo6qSjf1tuYXhCu2EZLftq+DSt5Z7fsIKr2P+lDgdTPWgLfZB1tJKzNcwKKOdf6q9Qmmxn7lJuI/gq5LrKw==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/sdk@0.33.1':
     resolution: {integrity: sha512-1mcOQVGr9rSrVcbKPNVzbZ8eCl1K0FATsYH3WJ/MH4WcZDWGECWrXJPNMZoEAkLxWiMe8jOQBumg2pmcDa9zpQ==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/superstruct@3.2.1':
     resolution: {integrity: sha512-fLgJnDOXFmuVlB38rUN5SmU7hAFQcCjrg3Vrxz67KTY7YHFnSNEKvX4avmEBdOI0yTCxZjwMCFEqsC8k2+Wd3g==}
@@ -970,7 +971,7 @@ packages:
 
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
-    deprecated: 'The package is now available as "qr": npm install qr'
+    deprecated: 'Switch to "qr" (new package name) for security updates: npm install qr'
 
   '@phosphor-icons/webcomponents@2.1.5':
     resolution: {integrity: sha512-JcvQkZxvcX2jK+QCclm8+e8HXqtdFW9xV4/kk2aL9Y3dJA2oQVt+pzbv1orkumz3rfx4K9mn9fDoMr1He1yr7Q==}
@@ -1130,6 +1131,15 @@ packages:
   '@reown/appkit@1.8.15':
     resolution: {integrity: sha512-eO3lcZvXwkcBZqpV+7InlzbLddP/wIJjaqbzlyCJAb0PfQ6fY40etiVpK38eFEDX1WGEYOvhKVO6aMgZtaO2lg==}
 
+  '@rollup/plugin-image@3.0.3':
+    resolution: {integrity: sha512-qXWQwsXpvD4trSb8PeFPFajp8JLpRtqqOeNYRUKnEQNHm7e5UP7fuSRcbjQAJ7wDZBbnJvSdY5ujNBQd9B1iFg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/plugin-typescript@12.3.0':
     resolution: {integrity: sha512-7DP0/p7y3t67+NabT9f8oTBFE6gGkto4SA6Np2oudYmZE/m1dt8RB0SjL1msMxFpLo631qjRCcBlAbq1ml/Big==}
     engines: {node: '>=14.0.0'}
@@ -1152,24 +1162,23 @@ packages:
       rollup:
         optional: true
 
-  '@rozoai/intent-common@0.1.5':
-    resolution: {integrity: sha512-aPMinmgpLwLu3YkVcBHs7Ge/xtM3uhqsvR4ZFJzfoXYK04IJRref5gl1qmlWcNoMgQqNG1+gDYWS7Sj/05Xg9g==}
+  '@rozoai/intent-common@0.1.21':
+    resolution: {integrity: sha512-9M8JaT7qMatpCuber07+K7FhOFmzc9qGcgFh7RYkyOpz9z9UoqVDLmuyye9ogwDbNU2COU/As6WO1t42Nv1DSw==}
 
-  '@rozoai/intent-pay@0.1.4':
-    resolution: {integrity: sha512-4xYo2VNZj8Bt4CqcIurtAHNCt95AAnUHmAW2EIGJy/kg/FnC4Ildv9plbiIOVir7FoJXalZMbssIZfLDo+0u4Q==}
+  '@rozoai/intent-pay@0.1.34':
+    resolution: {integrity: sha512-DP8hQHHFZbrGMTZsx+TxTgPim03ZS1FN87jKL0ZwQZVD4GUSl37a03YEXDZErwQ8gjeoNE+3GZy+HbVJpf5Vog==}
     engines: {node: '>=12.4'}
     peerDependencies:
       '@creit.tech/stellar-wallets-kit': ^1.9.5
       '@stellar/stellar-sdk': ^14.2.0
       '@tanstack/react-query': '>=5.0.0'
+      posthog-js: ^1.0.0
       react: 18.x || 19.x
       react-dom: 18.x || 19.x
       viem: 2.x
       wagmi: 2.x
     peerDependenciesMeta:
-      '@creit.tech/stellar-wallets-kit':
-        optional: true
-      '@stellar/stellar-sdk':
+      posthog-js:
         optional: true
 
   '@rtsao/scc@1.1.0':
@@ -1184,6 +1193,7 @@ packages:
   '@safe-global/safe-gateway-typescript-sdk@3.23.1':
     resolution: {integrity: sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw==}
     engines: {node: '>=16'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@scure/base@1.1.9':
     resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
@@ -1733,6 +1743,12 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/spl-memo@0.2.5':
+    resolution: {integrity: sha512-0Zx5t3gAdcHlRTt2O3RgGlni1x7vV7Xq7j4z9q8kKOMgU03PyoTbFQ/BSYCcICHzkaqD7ZxAiaJ6dlXolg01oA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.91.6
+
   '@solana/spl-token-group@0.0.7':
     resolution: {integrity: sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==}
     engines: {node: '>=16'}
@@ -1931,6 +1947,11 @@ packages:
     resolution: {integrity: sha512-UbNW6zbdOBXJwLAV2mMak0bIC9nw3IZVlQXkv2w2dk1jgCbJjy3oRVC943zeGE5JAm0Z9PHxrIjmkpGhayY7kw==}
     engines: {node: '>=20.0.0'}
 
+  '@stellar/stellar-base@14.1.0':
+    resolution: {integrity: sha512-A8kFli6QGy22SRF45IjgPAJfUNGjnI+R7g4DF5NZYVsD1kGf7B4ITyc4OPclLV9tqNI4/lXxafGEw0JEUbHixw==}
+    engines: {node: '>=20.0.0'}
+    deprecated: This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.
+
   '@stellar/stellar-sdk@13.3.0':
     resolution: {integrity: sha512-8+GHcZLp+mdin8gSjcgfb/Lb6sSMYRX6Nf/0LcSJxvjLQR0XHpjGzOiRbYb2jSXo51EnA6kAV5j+4Pzh5OUKUg==}
     engines: {node: '>=18.0.0'}
@@ -1939,9 +1960,10 @@ packages:
     resolution: {integrity: sha512-yu9E9fENEOgt26U/YaApQUUn6TRRhnEzzEOey3y43Nf4l08nbUmlzWYLMl9lcEzEilM68D3ENnEWxBuPylKLQQ==}
     engines: {node: '>=20.0.0'}
 
-  '@stellar/stellar-sdk@14.4.2':
-    resolution: {integrity: sha512-CYEYEoVXKM/Sw1j/5lhG4FcVq5WkqmSB+OBiEYxdTiwTy7rBzjPoyzzmDvO+cAoFTSkEGFikjDOFUFbgm+ntlQ==}
+  '@stellar/stellar-sdk@14.6.1':
+    resolution: {integrity: sha512-A1rQWDLdUasXkMXnYSuhgep+3ZZzyuXJKdt5/KAIc0gkmSp906HTvUpbT4pu+bVr41tu0+J4Ugz9J4BQAGGytg==}
     engines: {node: '>=20.0.0'}
+    hasBin: true
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -2654,6 +2676,7 @@ packages:
   '@worldcoin/idkit-core@2.1.0':
     resolution: {integrity: sha512-6MOFcOGqpk3iiW1i25NYmRJ6JUO8KetqS5Ic0l2cqnEEKvjMa/NT1+WTuenjTUF//Mqwy5kWgtVBzUqeyEfQ2g==}
     engines: {node: '>=12.4'}
+    deprecated: Old-versions moved to new ones
 
   '@worldcoin/minikit-js@1.9.9':
     resolution: {integrity: sha512-Tw6XVDiZ0nkU8WY12Mi5LCQeSMDtTkIyhT/6IJS8SkiAGBPgltrXKxUzyhXGJSwc7PfdilEhRdShVGpNN+qZ6Q==}
@@ -2719,6 +2742,10 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -2830,6 +2857,9 @@ packages:
 
   axios@1.13.2:
     resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
+
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -3118,9 +3148,6 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  colorette@2.0.20:
-    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
-
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -3222,9 +3249,6 @@ packages:
   date-fns@2.30.0:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
-
-  dateformat@4.6.3:
-    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
   dayjs@1.11.13:
     resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
@@ -3631,9 +3655,6 @@ packages:
     resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
     engines: {node: '> 0.1.90'}
 
-  fast-copy@3.0.2:
-    resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
-
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -3725,6 +3746,15 @@ packages:
 
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -3885,9 +3915,6 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  help-me@5.0.0:
-    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
-
   hermes-compiler@0.0.0:
     resolution: {integrity: sha512-boVFutx6ME/Km2mB6vvsQcdnazEYYI/jV1pomx1wcFUG/EVqTkr5CU0CW9bKipOA/8Hyu3NYwW3THg2Q1kNCfA==}
 
@@ -3923,6 +3950,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -4225,10 +4256,6 @@ packages:
 
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
-
-  joycon@3.1.1:
-    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
-    engines: {node: '>=10'}
 
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
@@ -4570,6 +4597,10 @@ packages:
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
+    hasBin: true
+
+  mini-svg-data-uri@1.4.4:
+    resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
 
   minimalistic-assert@1.0.1:
@@ -4925,15 +4956,8 @@ packages:
   pino-abstract-transport@0.5.0:
     resolution: {integrity: sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==}
 
-  pino-abstract-transport@1.2.0:
-    resolution: {integrity: sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==}
-
   pino-abstract-transport@2.0.0:
     resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
-
-  pino-pretty@10.3.1:
-    resolution: {integrity: sha512-az8JbIYeN/1iLj2t0jR9DV48/LQ3RC6hZPpapKPkb84Q+yTidMCpgWxIT3N0flnBDilyBQ1luWNpOeJptjdp/g==}
-    hasBin: true
 
   pino-std-serializers@4.0.0:
     resolution: {integrity: sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==}
@@ -5126,6 +5150,10 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
@@ -5135,6 +5163,9 @@ packages:
 
   pushdata-bitcoin@1.0.1:
     resolution: {integrity: sha512-hw7rcYTJRAl4olM8Owe8x0fBuJJ+WGbMhQuLWOXEMN3PxPCKQHRkhfL+XG0+iXUmSHjkMmb3Ba55Mt21cZc9kQ==}
+
+  pusher-js@8.5.0:
+    resolution: {integrity: sha512-V7uzGi9bqOOOyM/6IkJdpFyjGZj7llz1v0oWnYkZKcYLvbz6VcHVLmzKqkvegjuMumpfIEKGLmWHwFb39XFCpw==}
 
   qrcode@1.5.3:
     resolution: {integrity: sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==}
@@ -5360,9 +5391,6 @@ packages:
     resolution: {integrity: sha512-lDFs9AAIaWP9UCdtWrotXWWF9t8PWgQDcxqgAnpM9rMqxb3Oaq2J0thzPVSxBwdJgyQtkU/sYtFtbM1RSt/iYA==}
     engines: {node: '>=18.0.0'}
 
-  secure-json-parse@2.7.0:
-    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
-
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -5493,9 +5521,6 @@ packages:
 
   sonic-boom@2.8.0:
     resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}
-
-  sonic-boom@3.8.1:
-    resolution: {integrity: sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==}
 
   sonic-boom@4.2.0:
     resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
@@ -5953,6 +5978,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   valtio@1.11.2:
@@ -6284,8 +6310,6 @@ snapshots:
 
   '@albedo-link/intent@0.12.0': {}
 
-  '@albedo-link/intent@0.13.0': {}
-
   '@alloc/quick-lru@5.2.0': {}
 
   '@babel/code-frame@7.27.1':
@@ -6558,7 +6582,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@creit.tech/stellar-wallets-kit@1.9.5(cc274b20850c1f3d16c0d46698b20656)':
+  '@creit.tech/stellar-wallets-kit@1.9.5(0bf60eba65f72a2bc752b927274fc22b)':
     dependencies:
       '@albedo-link/intent': 0.12.0
       '@creit.tech/xbull-wallet-connect': 0.4.0
@@ -6572,7 +6596,7 @@ snapshots:
       '@ngneat/elf-entities': 5.0.2(@ngneat/elf@2.5.1(rxjs@7.8.1))(rxjs@7.8.1)
       '@ngneat/elf-persist-state': 1.2.1(rxjs@7.8.1)
       '@stellar/freighter-api': 5.0.0
-      '@stellar/stellar-base': 14.0.4
+      '@stellar/stellar-base': 14.1.0
       '@trezor/connect-plugin-stellar': 9.2.1(@stellar/stellar-sdk@14.1.1)(@trezor/connect@9.6.2(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(tslib@2.8.1)
       '@trezor/connect-web': 9.6.2(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@walletconnect/modal': 2.6.2(@types/react@19.2.7)(react@19.2.3)
@@ -8134,6 +8158,11 @@ snapshots:
       - ws
       - zod
 
+  '@rollup/plugin-image@3.0.3':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0
+      mini-svg-data-uri: 1.4.4
+
   '@rollup/plugin-typescript@12.3.0(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
       '@rollup/pluginutils': 5.3.0
@@ -8148,30 +8177,34 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 4.0.3
 
-  '@rozoai/intent-common@0.1.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@rozoai/intent-common@0.1.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@scure/base': 1.2.6
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@stellar/stellar-sdk': 14.4.2
+      '@stellar/stellar-sdk': 14.6.1
       viem: 2.43.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - bufferutil
       - debug
       - encoding
+      - supports-color
       - typescript
       - utf-8-validate
 
-  '@rozoai/intent-pay@0.1.4(6bc0fb300f5ab6b37fe23369862ef2d5)':
+  '@rozoai/intent-pay@0.1.34(d990a992352e99d7b2389237b3e34b2b)':
     dependencies:
-      '@albedo-link/intent': 0.13.0
+      '@creit.tech/stellar-wallets-kit': 1.9.5(0bf60eba65f72a2bc752b927274fc22b)
       '@reown/appkit': 1.8.15(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)))(@types/react@19.2.7)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      '@rollup/plugin-image': 3.0.3
       '@rollup/plugin-typescript': 12.3.0(tslib@2.8.1)(typescript@5.9.3)
-      '@rozoai/intent-common': 0.1.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@rozoai/intent-common': 0.1.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/spl-memo': 0.2.5(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-react': 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@5.9.3)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@stellar/stellar-sdk': 14.1.1
       '@tanstack/react-query': 5.90.12(react@19.2.3)
       '@trpc/client': 11.8.1(@trpc/server@11.8.1(typescript@5.9.3))(typescript@5.9.3)
       '@trpc/server': 11.8.1(typescript@5.9.3)
@@ -8181,7 +8214,7 @@ snapshots:
       buffer: 6.0.3
       detect-browser: 5.3.0
       framer-motion: 11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      pino-pretty: 10.3.1
+      pusher-js: 8.5.0
       qrcode: 1.5.4
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
@@ -8192,8 +8225,7 @@ snapshots:
       viem: 2.43.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       wagmi: 2.19.5(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.2.7)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.43.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
     optionalDependencies:
-      '@creit.tech/stellar-wallets-kit': 1.9.5(cc274b20850c1f3d16c0d46698b20656)
-      '@stellar/stellar-sdk': 14.1.1
+      posthog-js: 1.318.2
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -8224,6 +8256,7 @@ snapshots:
       - react-is
       - react-native
       - rollup
+      - supports-color
       - tslib
       - typescript
       - uploadthing
@@ -9080,6 +9113,11 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/spl-memo@0.2.5(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      buffer: 6.0.3
+
   '@solana/spl-token-group@0.0.7(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -9477,6 +9515,15 @@ snapshots:
       buffer: 6.0.3
       sha.js: 2.4.12
 
+  '@stellar/stellar-base@14.1.0':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@stellar/js-xdr': 3.1.2
+      base32.js: 0.1.0
+      bignumber.js: 9.3.1
+      buffer: 6.0.3
+      sha.js: 2.4.12
+
   '@stellar/stellar-sdk@13.3.0':
     dependencies:
       '@stellar/stellar-base': 13.1.0
@@ -9504,11 +9551,12 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@stellar/stellar-sdk@14.4.2':
+  '@stellar/stellar-sdk@14.6.1':
     dependencies:
-      '@stellar/stellar-base': 14.0.4
-      axios: 1.13.2
+      '@stellar/stellar-base': 14.1.0
+      axios: 1.18.1
       bignumber.js: 9.3.1
+      commander: 14.0.2
       eventsource: 2.0.2
       feaxios: 0.0.23
       randombytes: 2.1.0
@@ -9516,6 +9564,7 @@ snapshots:
       urijs: 1.19.11
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -11393,6 +11442,12 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
 
   agentkeepalive@4.6.0:
@@ -11530,6 +11585,16 @@ snapshots:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
+
+  axios@1.18.1:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   axobject-query@4.1.0: {}
 
@@ -11856,8 +11921,6 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  colorette@2.0.20: {}
-
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -11969,8 +12032,6 @@ snapshots:
   date-fns@2.30.0:
     dependencies:
       '@babel/runtime': 7.28.4
-
-  dateformat@4.6.3: {}
 
   dayjs@1.11.13: {}
 
@@ -12510,8 +12571,6 @@ snapshots:
 
   eyes@0.1.8: {}
 
-  fast-copy@3.0.2: {}
-
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.1:
@@ -12598,6 +12657,8 @@ snapshots:
   flow-enums-runtime@0.0.6: {}
 
   follow-redirects@1.15.11: {}
+
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:
@@ -12763,8 +12824,6 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  help-me@5.0.0: {}
-
   hermes-compiler@0.0.0: {}
 
   hermes-estree@0.25.1: {}
@@ -12808,6 +12867,13 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -13155,8 +13221,6 @@ snapshots:
   jiti@2.6.1: {}
 
   jose@6.1.3: {}
-
-  joycon@3.1.1: {}
 
   js-base64@3.7.8: {}
 
@@ -13598,6 +13662,8 @@ snapshots:
 
   mime@1.6.0: {}
 
+  mini-svg-data-uri@1.4.4: {}
+
   minimalistic-assert@1.0.1: {}
 
   minimalistic-crypto-utils@1.0.1: {}
@@ -13987,31 +14053,9 @@ snapshots:
       duplexify: 4.1.3
       split2: 4.2.0
 
-  pino-abstract-transport@1.2.0:
-    dependencies:
-      readable-stream: 4.7.0
-      split2: 4.2.0
-
   pino-abstract-transport@2.0.0:
     dependencies:
       split2: 4.2.0
-
-  pino-pretty@10.3.1:
-    dependencies:
-      colorette: 2.0.20
-      dateformat: 4.6.3
-      fast-copy: 3.0.2
-      fast-safe-stringify: 2.1.1
-      help-me: 5.0.0
-      joycon: 3.1.1
-      minimist: 1.2.8
-      on-exit-leak-free: 2.1.2
-      pino-abstract-transport: 1.2.0
-      pump: 3.0.3
-      readable-stream: 4.7.0
-      secure-json-parse: 2.7.0
-      sonic-boom: 3.8.1
-      strip-json-comments: 3.1.1
 
   pino-std-serializers@4.0.0: {}
 
@@ -14158,6 +14202,8 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  proxy-from-env@2.1.0: {}
+
   pump@3.0.3:
     dependencies:
       end-of-stream: 1.4.5
@@ -14168,6 +14214,10 @@ snapshots:
   pushdata-bitcoin@1.0.1:
     dependencies:
       bitcoin-ops: 1.4.1
+
+  pusher-js@8.5.0:
+    dependencies:
+      tweetnacl: 1.0.3
 
   qrcode@1.5.3:
     dependencies:
@@ -14470,8 +14520,6 @@ snapshots:
       node-addon-api: 5.1.0
       node-gyp-build: 4.8.4
 
-  secure-json-parse@2.7.0: {}
-
   semver@6.3.1: {}
 
   semver@7.7.1: {}
@@ -14665,10 +14713,6 @@ snapshots:
     optional: true
 
   sonic-boom@2.8.0:
-    dependencies:
-      atomic-sleep: 1.0.0
-
-  sonic-boom@3.8.1:
     dependencies:
       atomic-sleep: 1.0.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
         specifier: 0.3.0-alpha.1
         version: 0.3.0-alpha.1
       '@rozoai/intent-common':
-        specifier: 0.1.21
-        version: 0.1.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+        specifier: 0.1.26
+        version: 0.1.26(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@rozoai/intent-pay':
-        specifier: 0.1.34
-        version: 0.1.34(d990a992352e99d7b2389237b3e34b2b)
+        specifier: 0.1.39
+        version: 0.1.39(d990a992352e99d7b2389237b3e34b2b)
       '@soroswap/sdk':
         specifier: 0.4.0
         version: 0.4.0
@@ -1162,11 +1162,11 @@ packages:
       rollup:
         optional: true
 
-  '@rozoai/intent-common@0.1.21':
-    resolution: {integrity: sha512-9M8JaT7qMatpCuber07+K7FhOFmzc9qGcgFh7RYkyOpz9z9UoqVDLmuyye9ogwDbNU2COU/As6WO1t42Nv1DSw==}
+  '@rozoai/intent-common@0.1.26':
+    resolution: {integrity: sha512-vnIGZK8KnFmiyACV856+Ac8yVWy3IDxKGzs1hB0p73bUOY7frFrvcndQPdqXEzEFWSVkmGdtqQvYtTj0b6bGNw==}
 
-  '@rozoai/intent-pay@0.1.34':
-    resolution: {integrity: sha512-DP8hQHHFZbrGMTZsx+TxTgPim03ZS1FN87jKL0ZwQZVD4GUSl37a03YEXDZErwQ8gjeoNE+3GZy+HbVJpf5Vog==}
+  '@rozoai/intent-pay@0.1.39':
+    resolution: {integrity: sha512-BovHk0fot/d7kVvVRoAOmKkyiYgD0qob5xEHi7L0duIvQx0cuFJJXRaB3DYat7ClU4Oijvuj7P2Hsb9WHAxN/Q==}
     engines: {node: '>=12.4'}
     peerDependencies:
       '@creit.tech/stellar-wallets-kit': ^1.9.5
@@ -1942,6 +1942,7 @@ packages:
   '@stellar/stellar-base@13.1.0':
     resolution: {integrity: sha512-90EArG+eCCEzDGj3OJNoCtwpWDwxjv+rs/RNPhvg4bulpjN/CSRj+Ys/SalRcfM4/WRC5/qAfjzmJBAuquWhkA==}
     engines: {node: '>=18.0.0'}
+    deprecated: This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.
 
   '@stellar/stellar-base@14.0.4':
     resolution: {integrity: sha512-UbNW6zbdOBXJwLAV2mMak0bIC9nw3IZVlQXkv2w2dk1jgCbJjy3oRVC943zeGE5JAm0Z9PHxrIjmkpGhayY7kw==}
@@ -5974,6 +5975,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
@@ -6519,6 +6521,7 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - immer
       - react
+      - supports-color
       - typescript
       - use-sync-external-store
       - utf-8-validate
@@ -6532,8 +6535,8 @@ snapshots:
       '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       abitype: 1.0.6(typescript@5.9.3)(zod@3.25.76)
-      axios: 1.13.2
-      axios-retry: 4.5.0(axios@1.13.2)
+      axios: 1.18.1
+      axios-retry: 4.5.0(axios@1.18.1)
       jose: 6.1.3
       md5: 2.3.0
       uncrypto: 0.1.3
@@ -6544,6 +6547,7 @@ snapshots:
       - debug
       - encoding
       - fastestsmallesttextencoderdecoder
+      - supports-color
       - typescript
       - utf-8-validate
       - ws
@@ -7792,6 +7796,7 @@ snapshots:
       - immer
       - ioredis
       - react
+      - supports-color
       - typescript
       - uploadthing
       - use-sync-external-store
@@ -7878,6 +7883,7 @@ snapshots:
       - immer
       - ioredis
       - react
+      - supports-color
       - typescript
       - uploadthing
       - use-sync-external-store
@@ -8036,6 +8042,7 @@ snapshots:
       - immer
       - ioredis
       - react
+      - supports-color
       - typescript
       - uploadthing
       - use-sync-external-store
@@ -8151,6 +8158,7 @@ snapshots:
       - immer
       - ioredis
       - react
+      - supports-color
       - typescript
       - uploadthing
       - use-sync-external-store
@@ -8177,7 +8185,7 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 4.0.3
 
-  '@rozoai/intent-common@0.1.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@rozoai/intent-common@0.1.26(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@scure/base': 1.2.6
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -8192,13 +8200,13 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@rozoai/intent-pay@0.1.34(d990a992352e99d7b2389237b3e34b2b)':
+  '@rozoai/intent-pay@0.1.39(d990a992352e99d7b2389237b3e34b2b)':
     dependencies:
       '@creit.tech/stellar-wallets-kit': 1.9.5(0bf60eba65f72a2bc752b927274fc22b)
       '@reown/appkit': 1.8.15(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)))(@types/react@19.2.7)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@rollup/plugin-image': 3.0.3
       '@rollup/plugin-typescript': 12.3.0(tslib@2.8.1)(typescript@5.9.3)
-      '@rozoai/intent-common': 0.1.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@rozoai/intent-common': 0.1.26(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/spl-memo': 0.2.5(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
@@ -8209,6 +8217,7 @@ snapshots:
       '@trpc/client': 11.8.1(@trpc/server@11.8.1(typescript@5.9.3))(typescript@5.9.3)
       '@trpc/server': 11.8.1(typescript@5.9.3)
       '@walletconnect/sign-client': 2.23.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.23.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@worldcoin/minikit-js': 1.9.9(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       bs58: 6.0.0
       buffer: 6.0.3
@@ -8307,7 +8316,7 @@ snapshots:
 
   '@scure/bip32@1.7.0':
     dependencies:
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
@@ -9527,7 +9536,7 @@ snapshots:
   '@stellar/stellar-sdk@13.3.0':
     dependencies:
       '@stellar/stellar-base': 13.1.0
-      axios: 1.13.2
+      axios: 1.18.1
       bignumber.js: 9.3.1
       eventsource: 2.0.2
       feaxios: 0.0.23
@@ -9537,6 +9546,7 @@ snapshots:
     transitivePeerDependencies:
       - bare-url
       - debug
+      - supports-color
 
   '@stellar/stellar-sdk@14.1.1':
     dependencies:
@@ -9688,6 +9698,7 @@ snapshots:
       - expo-constants
       - expo-localization
       - react-native
+      - supports-color
       - utf-8-validate
 
   '@trezor/blockchain-link@2.5.2(@solana/sysvars@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
@@ -10674,7 +10685,7 @@ snapshots:
 
   '@walletconnect/relay-api@1.0.11':
     dependencies:
-      '@walletconnect/jsonrpc-types': 1.0.3
+      '@walletconnect/jsonrpc-types': 1.0.4
 
   '@walletconnect/relay-auth@1.1.0':
     dependencies:
@@ -11573,9 +11584,9 @@ snapshots:
 
   axe-core@4.11.0: {}
 
-  axios-retry@4.5.0(axios@1.13.2):
+  axios-retry@4.5.0(axios@1.18.1):
     dependencies:
-      axios: 1.13.2
+      axios: 1.18.1
       is-retry-allowed: 2.2.0
 
   axios@1.13.2:

--- a/src/features/bridge/components/BridgeHistory.tsx
+++ b/src/features/bridge/components/BridgeHistory.tsx
@@ -79,12 +79,16 @@ export const BridgeHistory = ({
   useEffect(() => {
     const handleStorageChange = (e: StorageEvent) => {
       if (e.key === SOROSWAP_BRIDGE_HISTORY_STORAGE_KEY) {
-        loadHistory();
+        loadHistory().catch((error) => {
+          console.error("Failed to load bridge history:", error);
+        });
       }
     };
 
     const handleCustomEvent = () => {
-      loadHistory();
+      loadHistory().catch((error) => {
+        console.error("Failed to load bridge history:", error);
+      });
     };
 
     window.addEventListener("storage", handleStorageChange);

--- a/src/features/bridge/components/BridgeHistory.tsx
+++ b/src/features/bridge/components/BridgeHistory.tsx
@@ -34,11 +34,16 @@ export const BridgeHistory = ({
 }: BridgeHistoryProps) => {
   const [history, setHistory] = useState<BridgeHistoryItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [currentWalletAddress, setCurrentWalletAddress] = useState<
+  // Which wallet the loaded `history` belongs to. Deriving the displayed list
+  // from this avoids resetting state in an effect when the wallet changes.
+  const [historyWalletAddress, setHistoryWalletAddress] = useState<
     string | null
   >(null);
 
-  const loadHistory = useCallback(() => {
+  const displayHistory =
+    historyWalletAddress === walletAddress ? history : [];
+
+  const loadHistory = useCallback(async () => {
     try {
       // First, clean up any existing duplicates
       removeDuplicatePayments(walletAddress);
@@ -51,26 +56,25 @@ export const BridgeHistory = ({
           new Date(b.completedAt).getTime() - new Date(a.completedAt).getTime(),
       );
 
+      // Defer state updates to an async callback so they don't run synchronously
+      // inside the calling effect (which depends on the walletAddress prop).
+      await Promise.resolve();
+      setIsLoading(true);
       setHistory(sortedHistory);
+      setHistoryWalletAddress(walletAddress);
     } catch (error) {
       throw error;
     } finally {
       setIsLoading(false);
     }
-    // eslint-disable-line react-hooks/exhaustive-deps
   }, [walletAddress]);
 
   // Load history on mount and when wallet address changes
   useEffect(() => {
-    // Clear history when wallet changes
-    if (currentWalletAddress && currentWalletAddress !== walletAddress) {
-      setHistory([]);
-    }
-
-    setCurrentWalletAddress(walletAddress);
-    setIsLoading(true);
-    loadHistory();
-  }, [walletAddress, loadHistory, currentWalletAddress]);
+    loadHistory().catch((error) => {
+      console.error("Failed to load bridge history:", error);
+    });
+  }, [walletAddress, loadHistory]);
 
   useEffect(() => {
     const handleStorageChange = (e: StorageEvent) => {
@@ -90,7 +94,7 @@ export const BridgeHistory = ({
       window.removeEventListener("storage", handleStorageChange);
       window.removeEventListener("bridge-payment-completed", handleCustomEvent);
     };
-  }, []);
+  }, [loadHistory]);
 
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
@@ -120,7 +124,7 @@ export const BridgeHistory = ({
     );
   }
 
-  if (history.length === 0) {
+  if (displayHistory.length === 0) {
     return (
       <div className="flex flex-col items-center gap-2 py-6">
         <Clock className="text-secondary h-8 w-8" />
@@ -146,7 +150,7 @@ export const BridgeHistory = ({
       </div>
 
       <div className="max-h-[300px] space-y-2 overflow-y-auto">
-        {history.map((item) => {
+        {displayHistory.map((item) => {
           const isWithdraw = "type" in item && item.type === "withdraw";
           const Icon = isWithdraw ? ArrowDownLeft : ArrowUpRight;
           const chainName = item.toChain;

--- a/src/features/bridge/hooks/useBridgeController.tsx
+++ b/src/features/bridge/hooks/useBridgeController.tsx
@@ -626,13 +626,15 @@ export function useBridgeController() {
 
   // Create payment config when validation passes
   useEffect(() => {
-    // Skip config creation while validation fails. The displayed config is
-    // derived from `validation.canBridge` at the return below, so there's no
-    // need to reset the state here (that would just duplicate the validation).
+    // Skip config creation while validation fails. Clear the config built for
+    // the previous inputs so it can't be exposed for a render when validation
+    // flips back to true — the new config is only set after createPaymentConfig
+    // completes, and the displayed config is derived from `validation.canBridge`.
     if (!validation.canBridge) {
-      console.debug("[Bridge] Cannot bridge, skipping config creation", {
+      console.debug("[Bridge] Cannot bridge, clearing config", {
         reason: validation.disabledReason,
       });
+      setIntentConfig(null);
       return;
     }
 

--- a/src/features/bridge/hooks/useBridgeController.tsx
+++ b/src/features/bridge/hooks/useBridgeController.tsx
@@ -126,7 +126,9 @@ function useDebounce<T>(value: T, delay: number) {
 
   // Derive the debouncing flag instead of mirroring it in state — the value is
   // "debouncing" whenever the latest input differs from the committed one.
-  const isDebouncing = debouncedValue !== value;
+  // Object.is so equal-but-NaN values (e.g. NaN from parseFloat) settle as not
+  // debouncing instead of flipping forever.
+  const isDebouncing = !Object.is(debouncedValue, value);
   return { debouncedValue, isDebouncing };
 }
 

--- a/src/features/bridge/hooks/useBridgeController.tsx
+++ b/src/features/bridge/hooks/useBridgeController.tsx
@@ -111,16 +111,11 @@ function bridgeReducer(state: BridgeState, action: BridgeAction): BridgeState {
 
 function useDebounce<T>(value: T, delay: number) {
   const [debouncedValue, setDebouncedValue] = useState<T>(value);
-  const [isDebouncing, setIsDebouncing] = useState<boolean>(false);
 
   useEffect(() => {
-    // Mark as debouncing when value changes
-    setIsDebouncing(true);
-
     // Set up the debounce timer
     const handler = setTimeout(() => {
       setDebouncedValue(value);
-      setIsDebouncing(false);
     }, delay);
 
     // Cleanup function automatically handles timeout clearing
@@ -129,6 +124,9 @@ function useDebounce<T>(value: T, delay: number) {
     };
   }, [value, delay]);
 
+  // Derive the debouncing flag instead of mirroring it in state — the value is
+  // "debouncing" whenever the latest input differs from the committed one.
+  const isDebouncing = debouncedValue !== value;
   return { debouncedValue, isDebouncing };
 }
 
@@ -235,6 +233,19 @@ export function useBridgeController() {
       amount: debouncedAmount,
       type: independentField === "from" ? FeeType.ExactIn : FeeType.ExactOut,
       appId: BRIDGE_APP_ID,
+      // toChain follows the bridge destination: the selected chain when
+      // switching, otherwise Stellar.
+      toChain: fromChain === "stellar"
+        ? (chainToUSDC[destinationChainId]?.chainId ?? baseUSDC.chainId)
+        : rozoStellarUSDC.chainId,
+      // Source/destination pair for the fee route, mirroring createPaymentConfig:
+      // switching = Stellar -> selected chain, otherwise Base -> Stellar.
+      // The bridge only moves USDC, so the token symbols are hardcoded.
+      sourceChainId: fromChain === "stellar" ? rozoStellarUSDC.chainId : baseUSDC.chainId,
+      sourceTokenSymbol: "USDC",
+      destReceiverAddress:
+        (fromChain === "stellar" ? destinationAddress : userAddress) ?? "",
+      destTokenSymbol: "USDC",
     },
     {
       enabled: debouncedAmount > 0,
@@ -615,13 +626,13 @@ export function useBridgeController() {
 
   // Create payment config when validation passes
   useEffect(() => {
-    // Use validation to determine if we should create config
+    // Skip config creation while validation fails. The displayed config is
+    // derived from `validation.canBridge` at the return below, so there's no
+    // need to reset the state here (that would just duplicate the validation).
     if (!validation.canBridge) {
-      console.debug("[Bridge] Cannot bridge, clearing config", {
+      console.debug("[Bridge] Cannot bridge, skipping config creation", {
         reason: validation.disabledReason,
       });
-      setIntentConfig(null);
-      setIsConfigLoading(false);
       return;
     }
 
@@ -661,7 +672,9 @@ export function useBridgeController() {
       try {
         // Withdraw
         if (isTokenSwitched) {
-          const sourceChain = e.chainId ? getChainName(e.chainId) : null;
+          const sourceChain = e.sourceChainId
+            ? getChainName(e.sourceChainId)
+            : null;
           const fromChainName = sourceChain ?? "Stellar";
           const toChainName = normalizeChainName(destinationChainId);
           const sentAmount =
@@ -680,7 +693,9 @@ export function useBridgeController() {
           });
         } else {
           // Deposit
-          const sourceChain = e.chainId ? getChainName(e.chainId) : null;
+          const sourceChain = e.sourceChainId
+            ? getChainName(e.sourceChainId)
+            : null;
           const fromChainName = sourceChain ?? "Any Chains";
           const toChainName = normalizeChainName(destinationChainId);
           const sentAmount =
@@ -733,8 +748,11 @@ export function useBridgeController() {
     // trustline data
     trustlineData,
 
-    // payment config
-    intentConfig,
+    // payment config — `validation.canBridge` acts as the discriminator, so the
+    // exposed config derives from it instead of being reset in an effect. The
+    // loading flag is returned raw: config hiding is handled above, and gating
+    // it on `canBridge` would hide the spinner mid-flight if validation flips.
+    intentConfig: validation.canBridge ? intentConfig : null,
     isConfigLoading,
     getActionButtonDisabled,
 

--- a/src/features/bridge/hooks/useGetFee.ts
+++ b/src/features/bridge/hooks/useGetFee.ts
@@ -94,7 +94,15 @@ export const useGetFee = (
       params.destTokenSymbol,
     ],
     queryFn: () => getFeeRequest(params),
-    enabled: (options?.enabled ?? true) && params.amount > 0,
+    // Only fire once the routing inputs the SDK needs are present, not just a
+    // positive amount — an empty destReceiverAddress or missing chain ids would
+    // otherwise trigger a doomed request on every keystroke.
+    enabled:
+      (options?.enabled ?? true) &&
+      params.amount > 0 &&
+      params.toChain > 0 &&
+      params.sourceChainId > 0 &&
+      !!params.destReceiverAddress,
     refetchInterval: options?.refetchInterval,
     staleTime: 30000, // 30 seconds
     retry: false, // Don't retry on error

--- a/src/features/bridge/hooks/useGetFee.ts
+++ b/src/features/bridge/hooks/useGetFee.ts
@@ -1,11 +1,20 @@
-import { FeeType } from "@rozoai/intent-common";
+import { FeeType, getFee } from "@rozoai/intent-common";
 import { useQuery } from "@tanstack/react-query";
+import { BRIDGE_APP_ID } from "../constants/bridge";
 
 export interface GetFeeParams {
   amount: number;
   type?: FeeType;
   appId?: string;
   currency?: string;
+  /** Destination chain id (the bridge "toChain"). */
+  toChain: number;
+  /** Source chain id (where the user sends from). */
+  sourceChainId: number;
+  sourceTokenSymbol: string;
+  /** Destination wallet address (receiver on the destination chain). */
+  destReceiverAddress: string;
+  destTokenSymbol: string;
 }
 
 export interface GetFeeResponse {
@@ -26,42 +35,42 @@ export interface GetFeeError {
   maxAllowed: number;
 }
 
-const fetchFee = async (params: GetFeeParams): Promise<GetFeeResponse> => {
-  if (params.amount <= 0) {
-    throw new Error("Amount must be greater than 0");
-  }
-
-  const queryParams = new URLSearchParams({
-    amount: params.amount.toString(),
-    type: params.type ?? "exactout",
-    ...(params.appId && { appId: params.appId }),
-    ...(params.currency && { currency: params.currency }),
+const getFeeRequest = async (params: GetFeeParams): Promise<GetFeeResponse> => {
+  const res = await getFee({
+    appId: params.appId ?? BRIDGE_APP_ID,
+    type: params.type ?? FeeType.ExactOut,
+    sourceChainId: String(params.sourceChainId),
+    sourceTokenSymbol: params.sourceTokenSymbol,
+    amount: String(params.amount),
+    destChainId: String(params.toChain),
+    destReceiverAddress: params.destReceiverAddress,
+    destTokenSymbol: params.destTokenSymbol,
   });
 
-  const response = await fetch(
-    `https://intentapi.rozo.ai/getFee?${queryParams.toString()}`,
-  );
-
-  if (!response.ok) {
-    const errorData = await response.json().catch(() => null);
-
-    if (errorData && errorData.error) {
-      // Throw the error data so we can access it in the component
-      throw errorData;
-    }
-
-    throw new Error(
-      `Failed to fetch fee: ${response.status} ${response.statusText}`,
-    );
+  if (res.error || !res.data) {
+    throw res.error ?? new Error("Failed to fetch fee");
   }
 
-  const data = await response.json();
+  const data = res.data;
+  const amountIn = parseFloat(data.source.amount);
+  const amountOut = parseFloat(data.destination.amount);
+  const fee = parseFloat(data.source.fee);
 
-  if (!data) {
-    throw new Error("Invalid response: data is undefined");
-  }
+  // `amount` mirrors the user's typed input (the independent field) so the
+  // caller's validity check (`feeData.amount === debouncedAmount`) holds for
+  // both ExactIn (source amount) and ExactOut (destination amount).
+  const amount = params.type === FeeType.ExactIn ? amountIn : amountOut;
 
-  return data;
+  return {
+    appId: params.appId ?? BRIDGE_APP_ID,
+    amount,
+    currency: params.currency ?? "",
+    fee,
+    feePercentage: data.feeInfo.feePercentage,
+    minimumFee: data.feeInfo.minimumFee,
+    amountIn,
+    amountOut,
+  };
 };
 
 export const useGetFee = (
@@ -78,8 +87,13 @@ export const useGetFee = (
       params.appId,
       params.currency,
       params.type,
+      params.toChain,
+      params.sourceChainId,
+      params.sourceTokenSymbol,
+      params.destReceiverAddress,
+      params.destTokenSymbol,
     ],
-    queryFn: () => fetchFee(params),
+    queryFn: () => getFeeRequest(params),
     enabled: (options?.enabled ?? true) && params.amount > 0,
     refetchInterval: options?.refetchInterval,
     staleTime: 30000, // 30 seconds

--- a/src/features/bridge/hooks/useUSDCTrustline.tsx
+++ b/src/features/bridge/hooks/useUSDCTrustline.tsx
@@ -21,6 +21,19 @@ import {
 } from "../utils/bridge";
 import { WalletNetwork } from "@creit.tech/stellar-wallets-kit";
 
+// Disconnected state, derived from `stellarAddress` at the return below so we
+// don't reset the status state in an effect when the wallet disconnects.
+const DISCONNECTED_TRUSTLINE: TrustlineStatus = {
+  exists: false,
+  balance: "0",
+  checking: false,
+};
+const DISCONNECTED_ACCOUNT: AccountStatus = {
+  exists: false,
+  xlmBalance: "0",
+  checking: false,
+};
+
 /**
  * Hook for managing USDC trustline operations
  * @param autoCheck - Whether to automatically check account/trustline when wallet connects (default: true)
@@ -195,22 +208,32 @@ export function useUSDCTrustline(
     }
   }, [kit, stellarAddress]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Auto-check account and trustline when wallet connects (only if autoCheck is enabled)
+  // Auto-check account and trustline when wallet connects (only if autoCheck is enabled).
+  // The await lives in the effect body so state updates happen in an async
+  // callback — a legitimate data load, not a prop-driven state reset.
   useEffect(() => {
-    if (stellarAddress && autoCheck) {
-      checkAccountAndTrustline();
-    } else if (!stellarAddress) {
-      // Reset status when disconnected - show disconnected state, not loading
-      setTrustlineStatus({ exists: false, balance: "0", checking: false });
-      setAccountStatus({ exists: false, xlmBalance: "0", checking: false });
-      setHasCheckedOnce(false);
-    }
+    if (!(stellarAddress && autoCheck)) return;
+    (async () => {
+      await checkAccountAndTrustline();
+    })().catch((error) => {
+      console.error("Failed to auto-check account and trustline:", error);
+    });
   }, [stellarAddress, autoCheck]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // The wallet's connection state is the discriminator: when there's no address
+  // the exposed status is the disconnected state, derived rather than reset.
+  const effectiveTrustlineStatus = stellarAddress
+    ? trustlineStatus
+    : DISCONNECTED_TRUSTLINE;
+  const effectiveAccountStatus = stellarAddress
+    ? accountStatus
+    : DISCONNECTED_ACCOUNT;
+  const effectiveHasCheckedOnce = stellarAddress ? hasCheckedOnce : false;
+
   return {
-    trustlineStatus,
-    accountStatus,
-    hasCheckedOnce,
+    trustlineStatus: effectiveTrustlineStatus,
+    accountStatus: effectiveAccountStatus,
+    hasCheckedOnce: effectiveHasCheckedOnce,
     checkAccountAndTrustline,
     refreshBalance,
     createTrustline,

--- a/src/features/bridge/hooks/useUSDCTrustline.tsx
+++ b/src/features/bridge/hooks/useUSDCTrustline.tsx
@@ -82,6 +82,10 @@ export function useUSDCTrustline(
   // Tracks which address the current status state belongs to, so results from a
   // previous wallet aren't exposed when a different address connects.
   const checkedAddressRef = useRef<string | null>(null);
+  // Tracks the address of an in-flight check so the concurrency guard is
+  // address-aware: a switch to a new wallet starts a fresh lookup even if a
+  // previous address's request is still running.
+  const checkingAddressRef = useRef<string | null>(null);
 
   // Check both account status and USDC trustline in one request
   const checkAccountAndTrustline = useCallback(async () => {
@@ -92,11 +96,13 @@ export function useUSDCTrustline(
       return;
     }
 
-    // Avoid concurrent checks that could cause UI flicker
-    if (trustlineStatus.checking || accountStatus.checking) {
+    // Avoid concurrent checks for the SAME address (prevents flicker). A switch
+    // to a different address must always be allowed to start its own lookup.
+    if (checkingAddressRef.current === stellarAddress) {
       return;
     }
 
+    checkingAddressRef.current = stellarAddress;
     setTrustlineStatus((prev) => ({ ...prev, checking: true }));
     setAccountStatus((prev) => ({ ...prev, checking: true }));
 
@@ -116,7 +122,11 @@ export function useUSDCTrustline(
       });
 
       setHasCheckedOnce(true);
-      checkedAddressRef.current = stellarAddress;
+      // Only record the result if this is still the active check for this
+      // address — a newer check for a different address may have started.
+      if (checkingAddressRef.current === stellarAddress) {
+        checkedAddressRef.current = stellarAddress;
+      }
     } catch (error) {
       console.error("Failed to check account and trustline:", error);
       setTrustlineStatus({
@@ -130,8 +140,11 @@ export function useUSDCTrustline(
         checking: false,
       });
       setHasCheckedOnce(true);
+    } finally {
+      if (checkingAddressRef.current === stellarAddress) {
+        checkingAddressRef.current = null;
+      }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [stellarAddress]);
 
   // Refresh only the USDC balance without checking account status

--- a/src/features/bridge/hooks/useUSDCTrustline.tsx
+++ b/src/features/bridge/hooks/useUSDCTrustline.tsx
@@ -8,7 +8,7 @@ import {
   Operation,
   TransactionBuilder,
 } from "@stellar/stellar-sdk";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { USDC_ASSET_MAINNET, USDC_ASSET_TESTNET } from "../constants/bridge";
 import {
   AccountStatus,
@@ -32,6 +32,19 @@ const DISCONNECTED_ACCOUNT: AccountStatus = {
   exists: false,
   xlmBalance: "0",
   checking: false,
+};
+
+// Checking state shown for a newly connected wallet until its own account and
+// trustline have been verified — prevents exposing a previous wallet's results.
+const CHECKING_TRUSTLINE: TrustlineStatus = {
+  exists: false,
+  balance: "0",
+  checking: true,
+};
+const CHECKING_ACCOUNT: AccountStatus = {
+  exists: false,
+  xlmBalance: "0",
+  checking: true,
 };
 
 /**
@@ -66,11 +79,16 @@ export function useUSDCTrustline(
     string | null
   >(null);
 
+  // Tracks which address the current status state belongs to, so results from a
+  // previous wallet aren't exposed when a different address connects.
+  const checkedAddressRef = useRef<string | null>(null);
+
   // Check both account status and USDC trustline in one request
   const checkAccountAndTrustline = useCallback(async () => {
     if (!stellarAddress) {
       setTrustlineStatus({ exists: false, balance: "0", checking: false });
       setAccountStatus({ exists: false, xlmBalance: "0", checking: false });
+      checkedAddressRef.current = null;
       return;
     }
 
@@ -98,6 +116,7 @@ export function useUSDCTrustline(
       });
 
       setHasCheckedOnce(true);
+      checkedAddressRef.current = stellarAddress;
     } catch (error) {
       console.error("Failed to check account and trustline:", error);
       setTrustlineStatus({
@@ -220,15 +239,27 @@ export function useUSDCTrustline(
     });
   }, [stellarAddress, autoCheck]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // The wallet's connection state is the discriminator: when there's no address
-  // the exposed status is the disconnected state, derived rather than reset.
-  const effectiveTrustlineStatus = stellarAddress
-    ? trustlineStatus
-    : DISCONNECTED_TRUSTLINE;
-  const effectiveAccountStatus = stellarAddress
-    ? accountStatus
-    : DISCONNECTED_ACCOUNT;
-  const effectiveHasCheckedOnce = stellarAddress ? hasCheckedOnce : false;
+  // The status state is only valid for the address it was last checked against.
+  // When disconnected, expose the disconnected state (derived, not reset).
+  // When connected but the status belongs to a different address, expose a
+  // checking state until the current address has been verified.
+  const statusBelongsToCurrentAddress =
+    stellarAddress !== null && checkedAddressRef.current === stellarAddress;
+  const effectiveTrustlineStatus = !stellarAddress
+    ? DISCONNECTED_TRUSTLINE
+    : statusBelongsToCurrentAddress
+      ? trustlineStatus
+      : CHECKING_TRUSTLINE;
+  const effectiveAccountStatus = !stellarAddress
+    ? DISCONNECTED_ACCOUNT
+    : statusBelongsToCurrentAddress
+      ? accountStatus
+      : CHECKING_ACCOUNT;
+  const effectiveHasCheckedOnce = !stellarAddress
+    ? false
+    : statusBelongsToCurrentAddress
+      ? hasCheckedOnce
+      : false;
 
   return {
     trustlineStatus: effectiveTrustlineStatus,

--- a/src/features/bridge/providers/RozoProvider.tsx
+++ b/src/features/bridge/providers/RozoProvider.tsx
@@ -12,52 +12,47 @@ import { useTheme } from "next-themes";
 import { type ReactNode, useEffect, useState } from "react";
 import { BridgeLoader } from "../components/BridgeLoader";
 
-export const wagmiConfig = createRozoWagmiConfig(
-  getDefaultConfig({
-    appName: "Soroswap",
-    appIcon: "https://app.soroswap.finance/SoroswapPurpleBlack.svg",
-    appUrl: "https://app.soroswap.finance/",
-  }),
-);
-
-const queryClient = new QueryClient();
-
 export function RozoProvider({ children }: { children: ReactNode }) {
   const { kit } = useUserContext();
   const { resolvedTheme } = useTheme();
 
-  // Avoid rendering provider while mounting to prevent setState during render in nested components
-  const [mounted, setMounted] = useState(false);
+  // Defer config construction to client render — module-scope createConfig
+  // runs during SSR and some wallet connectors touch window/localStorage.
+  const [config] = useState(() =>
+    createRozoWagmiConfig(
+      getDefaultConfig({
+        appName: "Soroswap",
+        appIcon: "https://app.soroswap.finance/SoroswapPurpleBlack.svg",
+        appUrl: "https://app.soroswap.finance/",
+        ssr: true,
+      }),
+    ),
+  );
+  const [queryClient] = useState(() => new QueryClient());
+
+  // Defer rendering RozoPayProvider until after the current render cycle to
+  // avoid setState calls during render in nested components.
   const [ready, setReady] = useState(false);
-  const [stableMode, setStableMode] = useState<"dark" | "light">("light");
 
   useEffect(() => {
-    setMounted(true);
-    // Delay rendering RozoPayProvider until after the current render cycle
-    // This prevents setState calls during render in nested components
     const timer = setTimeout(() => {
       setReady(true);
     }, 0);
     return () => clearTimeout(timer);
   }, []);
 
-  // Update mode only after mount to avoid triggering re-renders during initial render
-  useEffect(() => {
-    if (mounted && resolvedTheme) {
-      setStableMode(resolvedTheme === "dark" ? "dark" : "light");
-    }
-  }, [mounted, resolvedTheme]);
+  const mode = resolvedTheme === "dark" ? "dark" : "light";
 
-  // Wait until mounted, ready, and kit available
-  if (!mounted || !ready || !kit) return <BridgeLoader />;
+  // Wait until ready and kit available
+  if (!ready || !kit) return <BridgeLoader />;
 
   return (
-    <RozoWagmiProvider config={wagmiConfig}>
+    <RozoWagmiProvider config={config}>
       <QueryClientProvider client={queryClient}>
         <RozoPayProvider
           stellarKit={kit}
           stellarWalletPersistence={false}
-          mode={stableMode}
+          mode={mode}
           debugMode
         >
           {children}


### PR DESCRIPTION
## Summary

Follow-up to the Rozo bridge integration: upgrades the Rozo SDKs and cleans up the bridge feature's React/data-flow patterns so the UI no longer mutates state in prop-driven effects (a set of react-doctor findings) and the fee calculation uses the SDK's official `getFee` helper instead of a hand-rolled fetch.

## Changes

**SDK upgrade**
- Bump `@rozoai/intent-common` `0.1.5 → 0.1.21` and `@rozoai/intent-pay` `0.1.4 → 0.1.34` in `package.json` (lockfile regenerated).

**RozoProvider (`src/features/bridge/providers/RozoProvider.tsx`)**
- Build `wagmiConfig` and `QueryClient` inside `useState` initializers (lazy) instead of at module scope, and pass `ssr: true` to avoid touching `window`/`localStorage` during SSR.
- Drop the `mounted`/`stableMode` sync-state-on-effect patterns; `mode` is now derived directly from `resolvedTheme`, so it no longer updates state in an effect.

**useGetFee (`src/features/bridge/hooks/useGetFee.ts`)**
- Replace the custom `fetchFee` with `getFee` from `@rozoai/intent-common`.
- Add source/destination chain params (`toChain`, `sourceChainId`, `sourceTokenSymbol`, `destReceiverAddress`, `destTokenSymbol`) and map the nested SDK response back to the flat `GetFeeResponse` shape consumers expect.

**useBridgeController (`src/features/bridge/hooks/useBridgeController.tsx`)**
- Pass the new `getFee` params derived from the bridge direction (Stellar→selected chain for switch, Base→Stellar otherwise).
- `useDebounce` now derives `isDebouncing` instead of mirroring it in state.
- Expose `intentConfig` gated by `validation.canBridge` (derived, not reset in an effect); switch/withdraw history reads `e.sourceChainId`.

**useUSDCTrustline (`src/features/bridge/hooks/useUSDCTrustline.tsx`)**
- Track the checked address via `checkedAddressRef`; derive a disconnected/checking state instead of resetting status state when the wallet disconnects or changes.

**BridgeHistory (`src/features/bridge/components/BridgeHistory.tsx`)**
- Derive the displayed list from `historyWalletAddress` (avoids clearing state in an effect when the wallet prop changes); async state updates no longer run synchronously inside the effect.

## Test plan

- [ ] `pnpm install && pnpm build` succeeds with the new SDK versions
- [ ] `pnpm lint` passes
- [ ] Bridge: connect Stellar + EVM wallet, switch and withdraw flows show correct fee and config
- [ ] Disconnecting/reconnecting a wallet shows a fresh checking/disconnected trustline state, not a previous wallet's data
- [ ] Bridge history reloads and clears correctly when switching wallets


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented bridge history from showing stale entries during wallet switching and disconnects.
  * Improved USDC trustline and account status consistency for the connected Stellar address.
  * Refined fee estimation and bridge flow alignment with the selected transfer route and details.
  * Improved handling when bridging is unavailable.
  * Corrected stored bridge payment history chain names for deposit and withdrawal records.

* **Chores**
  * Updated bundled bridge-related dependencies to newer versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->